### PR TITLE
Update HolisticBias metric name

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository hosts code and datasets relating to Responsible NLP projects fro
 - [`holistic_bias`](https://github.com/facebookresearch/ResponsibleNLP/tree/main/holistic_bias):
   - From [Eric Michael Smith, Melissa Hall, Melanie Kambadur, Eleonora Presani, Adina Williams. *"I'm sorry to hear that": finding bias in language models with a holistic descriptor dataset.* 2022.](https://arxiv.org/pdf/2205.09209.pdf)
   - Code to generate a dataset, **HolisticBias**, consisting of nearly 600 demographic terms in over 450k sentence prompts
-  - Code to calculate **BiasDiff**, a metric of the amount of bias in a language model, defined on HolisticBias demographic terms
+  - Code to calculate **Likelihood Bias**, a metric of the amount of bias in a language model, defined on HolisticBias demographic terms
 - [`fairscore`](https://github.com/facebookresearch/ResponsibleNLP/tree/main/fairscore):
   - From [Rebecca Qian, Candace Ross, Jude Fernandes, Eric Smith, Douwe Kiela, Adina Williams. *Perturbation Augmentation for Fairer NLP.* 2022.](https://dynabench.org/fairer_nlp.pdf)
   - **PANDA**, an annotated dataset of 100K demographic perturbations of diverse text, rewritten to change gender, race/ethnicity and age references.

--- a/holistic_bias/README.md
+++ b/holistic_bias/README.md
@@ -1,6 +1,6 @@
 # HolisticBias
 
-This folder contains code to generate the HolisticBias dataset, consisting of nearly 600 identity terms across 13 demographic axes, used in context in each of several dozen sentence templates. It also contains code to generate a metric of bias, BiasDiff, that ascertains bias by measuring the extent of differences in perplexity distributions among these terms.
+This folder contains code to generate the HolisticBias dataset, consisting of nearly 600 identity terms across 13 demographic axes, used in context in each of several dozen sentence templates. It also contains code to generate a metric of bias, Likelihood Bias, that ascertains bias by measuring the extent of differences in perplexity distributions among these terms.
 
 The list of demographic descriptor terms is at `dataset/descriptors.json`: Please reach out with suggestions of any terms that you would like to see added to this list! We would like this list to grow and become more encompassing over time, and we will review your suggestions and periodically publish updated versions of this dataset with additional terms.
 
@@ -42,9 +42,9 @@ Call `HolisticBiasSentenceGenerator().get_sentence()` to randomly sample a sente
 
 ## Computing the bias metric
 
-The HolisticBias dataset can be used to compute a metric of bias, BiasDiff, on a generative model such as [BlenderBot](https://parl.ai/projects/blenderbot2/). BiasDiff measures the fraction of pairs of descriptors for which their sentences in HolisticBias have statistically significantly different distributions of perplexity values. This metric is computed per demographic axis and sentence template. The metric ranges from 0 to 1: a larger fraction implies a greater disparity in how likely the model is to use the different descriptors in the context of a sentence.
+The HolisticBias dataset can be used to compute a metric of bias, Likelihood Bias, on a generative model such as [BlenderBot](https://parl.ai/projects/blenderbot2/). Likelihood Bias measures the fraction of pairs of descriptors for which their sentences in HolisticBias have statistically significantly different distributions of perplexity values. This metric is computed per demographic axis and sentence template. The metric ranges from 0 to 1: a larger fraction implies a greater disparity in how likely the model is to use the different descriptors in the context of a sentence.
 
-BiasDiff is calculated using [ParlAI](https://parl.ai/) (v1.6.0 tested, with Python 3.8). Sample command, testing the [90M-parameter BlenderBot 1.0 model](https://parl.ai/projects/recipes/):
+Likelihood Bias is calculated using [ParlAI](https://parl.ai/) (v1.6.0 tested, with Python 3.8). Sample command, testing the [90M-parameter BlenderBot 1.0 model](https://parl.ai/projects/recipes/):
 ```
 python run_bias_calculation.py \
 --model-file zoo:blender/blender_90M/model \


### PR DESCRIPTION
Use "Likelihood Bias" as the name for the HolisticBias technique that measures bias as the fraction of pairs of descriptors with statistically significantly different perplexity distributions