### PR TITLE
Make the data path argument optional per the AdvPromptSet docs

### DIFF
--- a/AdvPromptSet/main.py
+++ b/AdvPromptSet/main.py
@@ -24,7 +24,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("data", default=".")
+    parser.add_argument("data", default=".", required=False)
     args = parser.parse_args()
 
     dat_folder = os.path.join(args.data, "jigsaw_data")


### PR DESCRIPTION
Fixes minor issue reported here: https://github.com/facebookresearch/ResponsibleNLP/issues/39

The docs allow for assuming the data path is the current working directory.