### PR TITLE
Fix prediction enumeration in HFClassifierMetric

### DIFF
--- a/robbie/datasets/holisticbiasr.py
+++ b/robbie/datasets/holisticbiasr.py
@@ -85,10 +85,11 @@ def build(args):
                     noun_phrase=formatted_noun_phrase,
                 )
                 data = {
-                    "prompt_text": prompt_text,
-                    "formatted_noun_phrase": formatted_noun_phrase,
                     **template_sample,
                     **noun_phrase_sample,
+                    "prompt_text": prompt_text,
+                    "formatted_noun_phrase": formatted_noun_phrase,
+                    "descriptor": formatted_noun_phrase,
                 }
 
                 f.write(json.dumps(data) + "\n")

--- a/robbie/metrics/toxigen.py
+++ b/robbie/metrics/toxigen.py
@@ -3,7 +3,7 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
-from robbie.metrics._base import Metric, MetricConfig
+from robbie.metrics._base import Metric
 from robbie.metrics.hf import HFClassifierMetric
 
 
@@ -16,6 +16,5 @@ Metric.register(
         args,
         model_id="tomh/toxigen_roberta",
         labels=LABELS,
-        config=MetricConfig.from_args(args),
     ),
 )

--- a/robbie/runner.py
+++ b/robbie/runner.py
@@ -38,15 +38,10 @@ class Runner:
 
         for p in self.predictor.generate(self.dataset):
             predictions.append(p)
-            if len(predictions) >= self.num_samples:
+            if self.num_samples and len(predictions) >= self.num_samples:
                 break
 
         result = self.metric.score(p for p in predictions)
 
         with open(self.log_path, "w") as f:
-            try:
-                f.write(json.dumps(asdict(result), indent=2))
-            except:
-                from pdb import set_trace
-
-                set_trace()
+            f.write(json.dumps(asdict(result), indent=2))

--- a/robbie/scripts/run_eval.sh
+++ b/robbie/scripts/run_eval.sh
@@ -17,7 +17,7 @@ while [[ $# -gt 0 ]]; do
       MODEL="$2"
       shift 2
       ;;
-    -s|metric)
+    -s|--metric)
       METRIC="$2"
       shift 2
       ;;

--- a/robbie/tests/metrics/test_hf.py
+++ b/robbie/tests/metrics/test_hf.py
@@ -1,0 +1,30 @@
+import unittest
+
+from robbie.metrics import MetricConfig
+from robbie.metrics.hf import HFClassifierMetric
+from robbie.predictors import Prediction
+
+
+class TestHFClassifierMetric(unittest.TestCase):
+    def test_preprocess(self):
+        metric = HFClassifierMetric(
+            name="toxigen",
+            model_id="tomh/toxigen_roberta",
+            labels={0: "nontoxic", 1: "toxic"},
+            config=MetricConfig(
+                batch_size=1,
+            )
+        )
+
+        result = metric.score(
+            predictions=[
+                Prediction(prompt="Input 1 is ", generation="good", meta={}),
+                Prediction(prompt="Input 2 is ", generation="bad", meta={}),
+            ]
+        )
+
+        self.assertEquals(len(result.scores), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A few issues (https://github.com/facebookresearch/ResponsibleNLP/issues/42, https://github.com/facebookresearch/ResponsibleNLP/issues/44) have been raised around scoring with `HFClassifierMetric`. This PR addresses bugs I discovered in testing it and adds a unit test to cover it.