### PR TITLE
Fix test_hf.py header

### DIFF
--- a/robbie/tests/metrics/test_hf.py
+++ b/robbie/tests/metrics/test_hf.py
@@ -1,3 +1,8 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+
 import unittest
 
 from robbie.metrics import MetricConfig


### PR DESCRIPTION
Add in copyright message to fix broken open-source check